### PR TITLE
Make patroni config file management optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -149,6 +149,7 @@ The following parameters are available in the `patroni` class:
 * [`standby_cluster_port`](#-patroni--standby_cluster_port)
 * [`standby_cluster_primary_slot_name`](#-patroni--standby_cluster_primary_slot_name)
 * [`http_proxy`](#-patroni--http_proxy)
+* [`config_ensure`](#-patroni--config_ensure)
 
 ##### <a name="-patroni--scope"></a>`scope`
 
@@ -1164,6 +1165,14 @@ Data type: `Optional[Stdlib::HTTPUrl]`
 URI for an http(s) proxy, used for pip commands
 
 Default value: `undef`
+
+##### <a name="-patroni--config_ensure"></a>`config_ensure`
+
+Data type: `Enum['file','absent']`
+
+management of the main config. The config isn't required when you run only patroni::instance resources
+
+Default value: `'file'`
 
 ## Resource types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -254,6 +254,8 @@
 #   Refer to Standby configuration `slot` setting
 # @param http_proxy
 #   URI for an http(s) proxy, used for pip commands
+# @param config_ensure management of the main config. The config isn't required when you run only patroni::instance resources
+#
 class patroni (
 
   # Global Settings
@@ -406,6 +408,7 @@ class patroni (
   Boolean $service_enable = true,
   Optional[String[1]] $custom_pip_provider = undef,
   Optional[Stdlib::HTTPUrl] $http_proxy = undef,
+  Enum['file','absent'] $config_ensure = 'file',
 ) {
   if $manage_postgresql {
     class { 'postgresql::globals':
@@ -550,7 +553,7 @@ class patroni (
   }
 
   file { 'patroni_config':
-    ensure  => 'file',
+    ensure  => $config_ensure,
     path    => $config_path,
     owner   => $config_owner,
     group   => $config_group,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -400,6 +400,21 @@ describe 'patroni' do
           is_expected.to contain_python__pip('psycopg2').with(environment: ['PIP_PREFIX=/opt/app/patroni', 'http_proxy=https://proxy.corp.local:3128', 'https_proxy=https://proxy.corp.local:3128'])
         }
       end
+      context 'with no main instance and only distro packages' do
+        let :params do
+          {
+            scope: 'internal',
+            manage_postgresql_repo: false,
+            install_method: 'package',
+            postgresql_version: '15',
+            service_enable: false,
+            config_ensure: 'absent',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('patroni_config').with_ensure('absent') }
+      end
     end
   end
 end


### PR DESCRIPTION
The main config file isn't required when you only use the patroni@.service instances.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
